### PR TITLE
Changing context to spawn for multiprocessing Pool (bis)

### DIFF
--- a/data_parsing/tools.py
+++ b/data_parsing/tools.py
@@ -595,7 +595,7 @@ def GetSites(Paths, Sequences, Background, EmissionParameters, TransitionParamet
     if np_proc == 1:
         ScoredSites = dict([GetSitesForGene(curr_slice) for curr_slice in data])
     else:    
-        pool = multiprocessing.Pool(number_of_processes, maxtasksperchild=10)
+        pool = multiprocessing.get_context("spawn").Pool(number_of_processes, maxtasksperchild=10)
         results = pool.imap(GetSitesForGene, data, chunksize=1)
         pool.close()
         pool.join()        
@@ -1046,7 +1046,7 @@ def ParallelGetMostLikelyPath(MostLikelyPaths, Sequences, Background, EmissionPa
         results = [ParallelGetMostLikelyPathForGene(curr_slice) for curr_slice in data]
     else:
         print("Spawning processes")
-        pool = multiprocessing.Pool(number_of_processes, maxtasksperchild=5)
+        pool = multiprocessing.get_context("spawn").Pool(number_of_processes, maxtasksperchild=5)
         results = pool.imap(ParallelGetMostLikelyPathForGene, data, chunksize)
         pool.close()
         pool.join()

--- a/stat/emission_prob.py
+++ b/stat/emission_prob.py
@@ -413,9 +413,7 @@ def construct_glm_matrix(EmissionParameters, Sequences, Background, Paths, bg_ty
         #Create an iterator for the data
         list_gen = [(a, b, c) for (a, b) ,c  in itertools.product(zip(itertools.count(),list(Sequences.keys())), list(range(nr_of_rep)))]
         data = itertools.starmap(f, list_gen)
-    
-        pool = multiprocessing.Pool(number_of_processes, maxtasksperchild=100)
-
+        pool = multiprocessing.get_context("spawn").Pool(number_of_processes, maxtasksperchild=100)
         results = pool.imap(process_gene_for_glm_mat, data, chunksize=1)
         pool.close()
         pool.join()
@@ -455,9 +453,7 @@ def construct_glm_matrix(EmissionParameters, Sequences, Background, Paths, bg_ty
             #Create an iterator for the data            
             list_gen = [(a, b, c) for (a, b) ,c  in itertools.product(zip(itertools.count(),list(Background.keys())), list(range(nr_of_bck_rep)))]
             data = itertools.starmap(f, list_gen)
-        
-            pool = multiprocessing.Pool(number_of_processes, maxtasksperchild=100)
-
+            pool = multiprocessing.get_context("spawn").Pool(number_of_processes, maxtasksperchild=100)
             results = pool.imap(process_bck_gene_for_glm_mat, data, chunksize=1)
             pool.close()
             pool.join()
@@ -492,7 +488,7 @@ def process_bck_gene_for_glm_mat(data):
     '''
 
     CurrGenePath, gene_rep_back, gene, gene_nr, rep, NrOfStates, nr_of_genes, bg_type, fg_state, bg_state = data
-    
+
     #1) get the counts
     counts = {}
     if bg_type == 'Const':

--- a/stat/mixture_tools.py
+++ b/stat/mixture_tools.py
@@ -287,7 +287,7 @@ def Parallel_estimate_mixture_params(EmissionParameters, curr_counts_orig, curr_
 		results = [Parallel_estimate_single_mixture_params(args) for args in data]
 	else:
 		print("Spawning processes")
-		pool = multiprocessing.Pool(np_proc, maxtasksperchild=5)
+		pool = multiprocessing.get_context("spawn").Pool(np_proc, maxtasksperchild=5)
 		results = pool.imap(Parallel_estimate_single_mixture_params, data, chunksize=1)
 		pool.close()
 		pool.join()


### PR DESCRIPTION
Fixes #9

I also observed the issue described by timlai4 (program hanging at `pid, sts = os.waitpid(self.pid, flag)`, but it was inconsistent. It seemed like some processes were not joined at the end and left hanging, sporadic deadlocks. Are you on a Unix-based system timlai4? I have not observed any issue with h5py though.

The [Multiprocessing doc](https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods) highlights that the default process start methods are different across the OS. It is specified that the `fork` start method, which is the Unix-default start method, is unsafe for multithreaded process. 

I explicitly specified the `spawn` start method at the different Pool instantiations. It is difficult to say if it is a fix, since the problem was sporadic. I have tested it multiple times on a Unix system and have not had any issue. I have not tested this fix on other OS, but according to the documentation, `spawn` was already the method used for Windows and MacOS.

EDIT : Replaces #12, using a specific branch to PR instead of the master branch. 