### PR TITLE
error in mask_miRNA_positions - removing faulty if statement

### DIFF
--- a/omniCLIP.py
+++ b/omniCLIP.py
@@ -465,20 +465,19 @@ def mask_miRNA_positions(Sequences, GeneAnnotation):
             
             #Set for each field the sequences to zeros
             for curr_key in keys:
-                if curr_key in Sequences:
-                    if curr_key in Sequences[curr_gene]:
-                        for rep in list(Sequences[curr_gene][curr_key].keys()):
-                            if curr_key == 'Variants':
-                               #Convert the Variants to array 
-                                curr_seq = csr_matrix((Sequences[curr_gene]['Variants'][rep]['data'][:],Sequences[curr_gene]['Variants'][rep]['indices'][:], 
-                                    Sequences[curr_gene]['Variants'][rep]['indptr'][:]), shape=Sequences[curr_gene]['Variants'][rep]['shape'][:])
-                                
-                                ix_slice =  np.logical_and(curr_start <= curr_seq.indices, curr_seq.indices < curr_stop)
-                                Sequences[curr_gene]['Variants'][rep]['data'][ix_slice] = 0
-                            else:
-                                curr_seq = Sequences[curr_gene][curr_key][rep][:, :]
-                                curr_seq[:, curr_start: curr_stop] = 0
-                                Sequences[curr_gene][curr_key][rep][:, :] = curr_seq
+                if curr_key in Sequences[curr_gene]:
+                    for rep in list(Sequences[curr_gene][curr_key].keys()):
+                        if curr_key == 'Variants':
+                           #Convert the Variants to array
+                            curr_seq = csr_matrix((Sequences[curr_gene]['Variants'][rep]['data'][:],Sequences[curr_gene]['Variants'][rep]['indices'][:],
+                                Sequences[curr_gene]['Variants'][rep]['indptr'][:]), shape=Sequences[curr_gene]['Variants'][rep]['shape'][:])
+
+                            ix_slice =  np.logical_and(curr_start <= curr_seq.indices, curr_seq.indices < curr_stop)
+                            Sequences[curr_gene]['Variants'][rep]['data'][ix_slice] = 0
+                        else:
+                            curr_seq = Sequences[curr_gene][curr_key][rep][:, :]
+                            curr_seq[:, curr_start: curr_stop] = 0
+                            Sequences[curr_gene][curr_key][rep][:, :] = curr_seq
 
     return Sequences
 


### PR DESCRIPTION
mask_miRNA_positions was not modifying the Sequences due to an if statement which is always evaluated being False. The first level of keys in Sequences is genes and not attributes. The test for the presence of the different keys for a specific gene is already present in the for loop. The `if` statement has been removed, and the function was tested for desired behaviour.