### PR TITLE
fix #17 - parsing for _PAR_Y

### DIFF
--- a/omniCLIP.py
+++ b/omniCLIP.py
@@ -498,10 +498,11 @@ def mark_overlapping_positions(Sequences, GeneAnnotation):
             Sequences[gene]['mask'].create_dataset(rep, data=np.zeros(Sequences[gene]['Coverage'][rep][()].shape), compression="gzip", compression_opts=9, chunks=Sequences[gene]['Coverage'][rep][()].shape, dtype='i8')
 
     #Create a dictionary that stores the genes in the Gene annnotation
-    gene_dict = {}
+    genes = [
+        gene for gene in GeneAnnotation.features_of_type('gene')
+        if '_PAR_Y' not in gene.id]
 
-    for gene in  GeneAnnotation.features_of_type('gene'):
-        gene_dict[gene.id.split('.')[0]] = gene
+    gene_dict = {gene.id.split('.')[0]: gene for gene in genes}
 
     #Get Chromosomes:
     genes_chr_dict = defaultdict(list)
@@ -515,7 +516,6 @@ def mark_overlapping_positions(Sequences, GeneAnnotation):
         for gene in genes_chr_dict[chr]:
             interval_chr_dict[chr][gene.start : gene.stop] = gene
     
-    genes = [gene for gene in GeneAnnotation.features_of_type('gene')]
 
     #Iterate over the genes in the Sequences:
     for gene in genes:


### PR DESCRIPTION
Fix #17.

The error seems to stem from a gene not found to overlap itself in the chromosome interval tree. This might be due to the duplicated genes from chrX and chrY. In Ensembl/GENCODE, these genes are differentiated by the addition of "_PAR_Y" to the gene_id of the chrY copy. Because omniCLIP truncate the gene_ids to their root, it might be possible that the gene_id is linked to the wrong chr. 

This fix ignores the _PAR_Y copy of the gene, mimicking what is done during the initial parsing of the CLIP libraries. 