### PR TITLE
Cast n_iter to int since it can be numpy.float64

### DIFF
--- a/stat/trans.py
+++ b/stat/trans.py
@@ -187,7 +187,7 @@ def FitTransistionParametersSimple(Sequences, Background, TransitionParameters, 
     if verbosity > 0:
         print('Fitting transition parameters: III')
         print('Memory usage: %s (kb)' % resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)
-    n_iter = max(5, np.ceil(10**6 / Y.shape[0]))
+    n_iter = int(max(5, np.ceil(10**6 / Y.shape[0])))
     
 
     NewTransitionParametersLogReg = SGDClassifier(loss="log", max_iter = n_iter)


### PR DESCRIPTION
This line https://github.com/philippdre/omniCLIP/blob/master/stat/trans.py#L195 can fail since n_iter can be a numpy.float64.